### PR TITLE
Standardized Readme and edited License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016 Multiformats
+Copyright (c) 2016 Protocol Labs Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,9 +1,38 @@
 # c-multihashing
 
+[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
+[![](https://img.shields.io/badge/project-multiformats-blue.svg?style=flat-square)](https://github.com/multiformats/multiformats)
+[![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](https://webchat.freenode.net/?channels=%23ipfs)
+[![](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
+
 > Use all the functions in multihash, in C
 
 This is a **work in progress**. It will be worked on after [c-multihash](https://github.com/multiformats/c-multihash). It is in the vein of [js-multihash](https://github.com/multiformats/js-multihash).
 
+## Install
+
+```
+> TODO
+```
+
+## Usage
+
+```
+> TODO
+```
+
+## Maintainers
+
+Captain: [@Kubuxu](https://github.com/Kubuxu).
+
+## Contribute
+
+Contributions welcome. Please check out [the issues](https://github.com/multiformats/c-multihashing/issues).
+
+Check out our [contributing document](https://github.com/multiformats/multiformats/blob/master/contributing.md) for more information on how we work, and about contributing in general. Please be aware that all interactions related to multiformats are subject to the IPFS [Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
+
+Small note: If editing the README, please conform to the [standard-readme](https://github.com/RichardLitt/standard-readme) specification.
+
 ## License
 
-[MIT](LICENSE)
+[MIT](LICENSE) © 2016 Protocol Labs Inc.


### PR DESCRIPTION
Multiformats is not an entity; changed to Protocol Labs. Also filled out the README.